### PR TITLE
Update license info in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,4 +109,4 @@ hz_deinit();
 
 
 ## LICENSE
-Hamza is licensed under LGPLv3.
+Hamza is licensed under MIT license.


### PR DESCRIPTION
The readme.md still refers to the old license. This PR updates it to MIT.